### PR TITLE
Use new projectPath instead of parentFolder

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,10 +35,10 @@ export const entry = (API) => {
         rpc.setActivity({ ...defaultPresence });
     });
 
-    RunningConfig.on("aTabHasBeenFocused", ({ client, instance, parentFolder, directory, tabElement }) => {
+    RunningConfig.on("aTabHasBeenFocused", ({ client, instance, projectPath, directory, tabElement }) => {
         if (client) {
             const editingFile = path.basename(path.normalize(directory));
-            const workingProject = path.basename(path.normalize(parentFolder));
+            const workingProject = path.basename(path.normalize(projectPath));
             var file = client.do("getMode", { instance }).name;
             switch (file) {
                 case "application/json":


### PR DESCRIPTION
## Why
parentFolder refers to the file's parent folder, but no the project folder, projectPath does.

## Example
Suppose you just opened '.../Graviton-App/src/javascript/main.ts'
parentFolder would be '.../Graviton-App/src/javascript'
and projectPath would be '.../Graviton-App'

## Solution

Use projectPath instead of parentFolder, which makes more sense